### PR TITLE
Decode link types

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ foreach($doc->itemsIterator($pageLimit) as $pageNum => $items) {
 }
 ```
 
+Often, when fetching container docs such as "stories", you'll want to interrogate child items based on their profile types.  This SDK handles this for you, allowing the retrieval of just items-of-profile.
+
+```php
+echo "looking at a cdoc of profile = {$story->getProfileAlias()}\n";
+$items = $story->items();
+$audios = $story->items('audio');
+$images = $story->items('image');
+$videos = $story->items('video');
+
+echo "  contains {$items->count()} items\n";
+echo "           {$audios->count()} audios\n";
+echo "           {$images->count()} images\n";
+echo "           {$videos->count()} videos\n";
+```
+
 ### Document Links
 
 To navigate links, we can interrogate them directly on the `\Pmp\Sdk\CollectionDocJson` object, or browse them via the `\Pmp\Sdk\CollectionDocJsonLinks` object, containing a collection of `\Pmp\Sdk\CollectionDocJsonLink` objects.
@@ -204,6 +219,28 @@ if (!$creatorDoc) {
     exit(1);
 }
 echo "creator = {$creatorDoc->attributes->title}\n";
+```
+
+A document's `links.collection` will often contain PMP topics, series, properties, and contributors.  These links are normally distinguished by rels such as `urn:collectiondoc:collection:property`.  As a shortcut for finding these links, you can just refer to the last `property` segment of that urn.
+
+```php
+// these statements are equivalent
+$links = $doc->links('collection');
+$links = $doc->getCollections();
+
+// these statements are also equivalent
+$topicLinks = $doc->links('collection', 'urn:collectiondoc:collection:topic');
+$topicLinks = $doc->getCollections('urn:collectiondoc:collection:topic');
+$topicLinks = $doc->getCollections('topic');
+
+// more examples...
+$contribCount = $doc->getCollections('contributor')->count();
+$firstSeriesLink = $doc->getCollections('series')->first();
+$firstPropertyLink = $doc->getCollections('property')->first();
+if ($firstPropertyLink) {
+    $propertyDoc = $firstPropertyLink->follow();
+    echo "Got a property - {$propertyDoc->attributes->title}\n";
+}
 ```
 
 ### Modifying documents

--- a/src/Pmp/Sdk.php
+++ b/src/Pmp/Sdk.php
@@ -9,7 +9,7 @@ namespace Pmp;
  */
 class Sdk
 {
-    const VERSION = '1.0.0'; // UPDATE ME!!!
+    const VERSION = '1.0.1'; // UPDATE ME!!!
 
     const FETCH_DOC     = 'urn:collectiondoc:hreftpl:docs';
     const FETCH_PROFILE = 'urn:collectiondoc:hreftpl:profiles';

--- a/src/Pmp/Sdk/CollectionDocJsonItems.php
+++ b/src/Pmp/Sdk/CollectionDocJsonItems.php
@@ -62,4 +62,13 @@ class CollectionDocJsonItems extends \ArrayObject
         return ($link && isset($link->pagenum)) ? $link->pagenum : 1;
     }
 
+    /**
+     * Get the first item
+     *
+     * @return CollectionDocJson the first item or null
+     */
+    public function first() {
+        return count($this) > 0 ? $this[0] : null;
+    }
+
 }

--- a/src/Pmp/Sdk/CollectionDocJsonLinks.php
+++ b/src/Pmp/Sdk/CollectionDocJsonLinks.php
@@ -9,6 +9,8 @@ namespace Pmp\Sdk;
  */
 class CollectionDocJsonLinks extends \ArrayObject
 {
+    private $_links;
+    private $_auth;
 
     /**
      * Constructor
@@ -17,9 +19,11 @@ class CollectionDocJsonLinks extends \ArrayObject
      * @param AuthClient $auth authentication client for the API
      */
     public function __construct(array $links, AuthClient $auth = null) {
-        $linkObjects = array();
+        $this->_links = $links;
+        $this->_auth = $auth;
 
         // init links
+        $linkObjects = array();
         foreach($links as $link) {
             $linkObjects[] = new CollectionDocJsonLink($link, $auth);
         }
@@ -32,19 +36,19 @@ class CollectionDocJsonLinks extends \ArrayObject
      * Get the set of links matching an array of urns
      *
      * @param array $urn the names to match on
-     * @return array the matched links
+     * @return CollectionDocJsonLinks the matched links
      */
     public function rels(array $urns) {
-        $links = array();
-        foreach ($this as $link) {
+        $rawLinks = array();
+        foreach ($this as $idx => $link) {
             if (!empty($link->rels)) {
                 $match = array_diff($urns, $link->rels);
                 if (count($match) != count($urns)) {
-                    $links[] = $link;
+                    $rawLinks[] = $this->_links[$idx];
                 }
             }
         }
-        return $links;
+        return new CollectionDocJsonLinks($rawLinks, $this->_auth);
     }
 
     /**
@@ -55,7 +59,16 @@ class CollectionDocJsonLinks extends \ArrayObject
      */
     public function rel($urn) {
         $match = $this->rels(array($urn));
-        return empty($match) ? null : $match[0];
+        return count($match) > 0 ? $match[0] : null;
+    }
+
+    /**
+     * Get the first link in this collection
+     *
+     * @return CollectionDocJsonLink the first link or null
+     */
+    public function first() {
+        return count($this) > 0 ? $this[0] : null;
     }
 
 }

--- a/t/010-fetch.t
+++ b/t/010-fetch.t
@@ -9,7 +9,7 @@ require_once 'Common.php';
 $ARTS_TOPIC = '89944632-fe7c-47df-bc2c-b2036d823f98';
 
 // plan and connect
-list($host, $client_id, $client_secret) = pmp_client_plan(17);
+list($host, $client_id, $client_secret) = pmp_client_plan(22);
 ok( $sdk = new \Pmp\Sdk($host, $client_id, $client_secret), 'instantiate new Sdk' );
 
 // check the home doc
@@ -24,6 +24,7 @@ is( $doc->attributes->guid, $ARTS_TOPIC, 'fetch by guid - guid' );
 is( $doc->attributes->title, 'Arts', 'fetch by guid - title' );
 like( $doc->links->profile[0]->href, '/profiles\/topic$/', 'fetch by guid - profile link' );
 like( $doc->getProfile()->href, '/profiles\/topic$/', 'fetch by guid - profile shortcut' );
+is( $doc->getProfileAlias(), 'topic', 'fetch by guid - profile alias' );
 
 // fetch by alias
 ok( $doc = $sdk->fetchTopic('arts'), 'fetch by alias' );
@@ -31,6 +32,15 @@ like( $doc->href, '/topics\/arts/', 'fetch by alias - href' );
 is( $doc->attributes->guid, $ARTS_TOPIC, 'fetch by alias - guid' );
 is( $doc->attributes->title, 'Arts', 'fetch by alias - title' );
 like( $doc->getProfile()->href, '/profiles\/topic$/', 'fetch by alias - profile shortcut' );
+is( $doc->getProfileAlias(), 'topic', 'fetch by alias - profile alias' );
+
+// profile alias decoding
+$doc->links->profile[0]->href = "$host/profiles/foobar";
+is( $doc->getProfileAlias(), 'foobar', 'profile decoding - by alias' );
+$doc->links->profile[0]->href = "$host/docs/c07bd70c-8644-4c5d-933a-40d5d7032036";
+is( $doc->getProfileAlias(), 'series', 'profile decoding - by guid' );
+$doc->links->profile[0]->href = "$host/profiles/c07bd70c-8644-4c5d-933a-40d5d7032036";
+is( $doc->getProfileAlias(), 'series', 'profile decoding - by guid under profile endpoint' );
 
 // fetch 404
 is( $sdk->fetchDoc('foobar'), null, 'fetch guid 404 - returns null' );

--- a/t/013-follow-links.t
+++ b/t/013-follow-links.t
@@ -7,20 +7,36 @@ require_once 'Common.php';
 //
 
 // plan and connect
-list($host, $client_id, $client_secret) = pmp_client_plan(8);
+list($host, $client_id, $client_secret) = pmp_client_plan(17);
 ok( $sdk = new \Pmp\Sdk($host, $client_id, $client_secret), 'instantiate new Sdk' );
 
 // query docs
-$opts = array('limit' => 1, 'profile' => 'story', 'has' => 'image');
+$opts = array('limit' => 1, 'profile' => 'story', 'has' => 'image,audio');
 ok( $doc = $sdk->queryDocs($opts), 'query docs' );
 is( count($doc->items), 1, 'query docs - count items' );
 
 // load the creator link
-$items = $doc->items();
-$first_item = $items[0];
-$creator_links = $first_item->links('creator');
+$search_items = $doc->items();
+$story = $search_items[0];
+$creator_links = $story->links('creator');
 is( count($creator_links), 1, 'links - has creator' );
 ok( $creator = $creator_links[0]->follow(), 'links - follow creator' );
 is( $creator->href, $creator_links[0]->href, 'links - creator href' );
 ok( $creator->attributes->guid, 'links - creator guid' );
 ok( $creator->attributes->title, 'links - creator title' );
+
+// check items by profile
+$items  = $story->items();
+$images = $story->items('image');
+$audios = $story->items('audio');
+cmp_ok( $items->count(), '>=', 2, 'story items - at least 2 total' );
+cmp_ok( $images->count(), '>=', 1, 'story items - at least 1 image' );
+cmp_ok( $audios->count(), '>=', 1, 'story items - at least 1 audio' );
+cmp_ok( $images->count(), '<', $items->count(), 'story items - less than total images' );
+cmp_ok( $audios->count(), '<', $items->count(), 'story items - less than total audio' );
+is( $images->count() + $audios->count(), $items->count(), 'story items - adds up' );
+is( $story->items('foobar')->count(), 0, 'story items - no unknown profiles' );
+
+// follow items by profile
+is( $images[0]->getProfileAlias(), 'image', 'story image - profile alias' );
+is( $audios[0]->getProfileAlias(), 'audio', 'story audio - profile alias' );

--- a/t/014-collections.t
+++ b/t/014-collections.t
@@ -1,0 +1,63 @@
+#!/usr/bin/env php
+<?php
+require_once 'Common.php';
+
+//
+// search and follow collection links
+//
+
+// plan and connect
+list($host, $client_id, $client_secret) = pmp_client_plan(14);
+ok( $sdk = new \Pmp\Sdk($host, $client_id, $client_secret), 'instantiate new Sdk' );
+
+// doc with a bunch of collection links/rels
+$TEST_DOC = array(
+    'attributes' => array(
+        'guid'  => 'do-not-actually-save-this-doc',
+        'title' => 'PMP PHP SDK Test Document',
+        'tags'  => array('pmp_php_sdk_test_doc'),
+    ),
+    'links' => array(
+        'collection' => array(
+            array(
+                'href' => "$host/topics/arts",
+                'rels' => array('urn:collectiondoc:collection:property'),
+            ),
+            array(
+                'href' => "$host/topics/food",
+                'rels' => array('urn:collectiondoc:collection:series'),
+            ),
+            array(
+                'href' => "$host/topics/health",
+                'rels' => array('urn:collectiondoc:collection:topic'),
+            ),
+            array(
+                'href' => "$host/topics/education",
+                'rels' => array('urn:collectiondoc:collection:topic'),
+            ),
+            array(
+                'href' => "$host/topics/foobar",
+            ),
+        ),
+    ),
+);
+ok( $doc = $sdk->newDoc('story', $TEST_DOC), 'create doc - new' );
+is( $doc->href, null, 'create doc - href' );
+is( $doc->getProfileAlias(), 'story', 'create doc - profile' );
+
+// all collection links
+is( $doc->links('collection')->count(), 5, 'collection links - count' );
+is( $doc->links('collection', 'urn:collectiondoc:collection:topic')->count(), 2, 'collection links - count with urn' );
+is( $doc->links('collection', 'nothingz')->count(), 0, 'collection links - count with bad urn' );
+
+// collection shortcut
+is( $doc->getCollections()->count(), 5, 'collection shortcut - count' );
+is( $doc->getCollections('urn:collectiondoc:collection:topic')->count(), 2, 'collection shortcut - topic by urn' );
+is( $doc->getCollections('topic')->count(), 2, 'collection shortcut - topic by alias' );
+is( $doc->getCollections('series')->count(), 1, 'collection shortcut - series' );
+is( $doc->getCollections('property')->count(), 1, 'collection shortcut - property' );
+
+// follow a shortcut
+$series = $doc->getCollections('series')->first()->follow();
+is( $series->attributes->title, 'Food', 'follow series - title' );
+is( $series->getProfileAlias(), 'topic', 'follow series - profile' );


### PR DESCRIPTION
Solve 2 common PMP client issues:

* Ability to distinguish between child `items`, based on profile types
 * Hard-coding some known profile guids for now ... but eventually should probably pull down and cache the profile aliases doc.
* Ability to distinguish between collection links, based on some known urns
  * `urn:collectiondoc:collection:contributor`
  * `urn:collectiondoc:collection:property`
  * `urn:collectiondoc:collection:series`
  * `urn:collectiondoc:collection:topic`

Usage examples:

```php
// collections matching known-urns
$doc->getCollections('topic')->count();
$doc->getCollections('series')->first();
$series = $doc->getCollections('series')->first()->follow();

// filtering items based on a profile alias
$doc->items()->count();
$doc->items('image')->count();
$doc->items('audio')->count();

// decode the profile alias of any doc
// case 1: it uses a /profiles/foobar alias
// case 2: it has a /docs/1234 guid that is a known-aliased-profile
$doc->getProfileAlias();
```