### PR TITLE
PHP 5.3 compatible phars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ clean:
 
 build:
 	mkdir -p build/staging
-	curl -s https://raw.githubusercontent.com/mtdowling/Burgomaster/0.0.1/src/Burgomaster.php > build/Burgomaster.php
+	curl -s https://raw.githubusercontent.com/mtdowling/Burgomaster/0.0.2/src/Burgomaster.php > build/Burgomaster.php
 	php packager.php
 
 .PHONY: test build

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ PHP version >= 5.3.3.  And a [PMP client-id/secret](https://support.pmp.io/login
  require 'path/to/pmpsdk.phar`;
  ```
 
+ **NOTE**: *if you see a strange error message full of question marks like `?r??PHP Fatal error:  Class 'Pmp\Sdk' not found`, make sure you turn off [detect unicode](http://stackoverflow.com/questions/11302593/how-to-disable-detect-unicode-setting-from-php-ini-trying-to-install-compose).*
+
 ## Usage
 
 ### Connecting

--- a/packager.php
+++ b/packager.php
@@ -13,19 +13,19 @@ $root     = dirname(__FILE__);
 $packager = new \Burgomaster($staging, $root);
 
 // basic text files
-foreach (['README.md', 'LICENSE'] as $file) {
+foreach (array('README.md', 'LICENSE') as $file) {
     $packager->deepCopy($file, $file);
 }
 
 // copy pmp core
-$packager->recursiveCopy('src/Pmp', 'Pmp', ['php']);
+$packager->recursiveCopy('src/Pmp', 'Pmp', array('php'));
 
 // copy vendor'd libs
-$packager->recursiveCopy('vendor/guzzle/guzzle/src/Guzzle', 'Guzzle', ['php', 'pem']);
-$packager->recursiveCopy('vendor/symfony/event-dispatcher/Symfony', 'Symfony', ['php']);
+$packager->recursiveCopy('vendor/guzzle/guzzle/src/Guzzle', 'Guzzle', array('php', 'pem'));
+$packager->recursiveCopy('vendor/symfony/event-dispatcher/Symfony', 'Symfony', array('php'));
 
 // autoload the PMP entry point
-$packager->createAutoloader(['Pmp/Sdk.php']);
+$packager->createAutoloader(array('Pmp/Sdk.php'));
 
 // create archive (TODO: would a zip even be useful?)
 $packager->createPhar("$root/build/pmpsdk.phar");


### PR DESCRIPTION
Was using an older version of Burgomaster, which was producing phar files with the newer array bracket `[]` syntax.